### PR TITLE
Add multisite support

### DIFF
--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -250,7 +250,7 @@ abstract class Batch {
 	 * @param  string $status Status of batch process.
 	 */
 	private function update_status( $status ) {
-		update_site_option( self::BATCH_HOOK_PREFIX . $this->slug, array(
+		update_option( self::BATCH_HOOK_PREFIX . $this->slug, array(
 			'status' => $status,
 			'timestamp' => current_time( 'timestamp' ),
 		) );

--- a/includes/batch-functions.php
+++ b/includes/batch-functions.php
@@ -41,10 +41,10 @@ function register( $args ) {
  * @return array
  */
 function get_all_batches() {
-	$batches = get_site_option( Batch::REGISTERED_BATCHES_KEY, array() );
+	$batches = get_option( Batch::REGISTERED_BATCHES_KEY, array() );
 
 	foreach ( $batches as $k => $batch ) {
-		if ( $batch_status = get_site_option( Batch::BATCH_HOOK_PREFIX . $k ) ) {
+		if ( $batch_status = get_option( Batch::BATCH_HOOK_PREFIX . $k ) ) {
 			$last_run = time_ago( $batch_status['timestamp'] );
 			$status = $batch_status['status'];
 		} else {
@@ -65,7 +65,7 @@ function get_all_batches() {
  * @param array $batches Batches you want to register.
  */
 function update_registered_batches( $batches ) {
-	return update_site_option( Batch::REGISTERED_BATCHES_KEY, $batches );
+	return update_option( Batch::REGISTERED_BATCHES_KEY, $batches );
 }
 
 /**
@@ -83,5 +83,5 @@ function time_ago( $time ) {
  * Clear all existing batches.
  */
 function clear_existing_batches() {
-	return update_site_option( Batch::REGISTERED_BATCHES_KEY, array() );
+	return update_option( Batch::REGISTERED_BATCHES_KEY, array() );
 }

--- a/tests/test-batch.php
+++ b/tests/test-batch.php
@@ -154,12 +154,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $post_batch->run( 1 );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertEquals( 'no results found', $batch_status['status'] );
 	}
 
@@ -186,12 +186,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $post_batch->run( 1 );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertEquals( 'finished', $batch_status['status'] );
 
 		// Loop through each post and make sure our value was set.
@@ -224,12 +224,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
+		$batch_status = get_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $user_batch->run( 1 );
 
-		$batch_status = get_site_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
+		$batch_status = get_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
 		$this->assertEquals( 'finished', $batch_status['status'] );
 
 		// Loop through each post and make sure our value was set.
@@ -340,12 +340,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $post_batch->run( 1 );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertEquals ( 'running', $batch_status['status'] );
 	}
 
@@ -369,12 +369,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $post_batch->run( 2 );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertEquals( 'finished', $batch_status['status'] );
 	}
 
@@ -395,12 +395,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
+		$batch_status = get_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $user_batch->run( 2 );
 
-		$batch_status = get_site_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
+		$batch_status = get_option( $user_batch::BATCH_HOOK_PREFIX . $user_batch->slug );
 		$this->assertEquals( 'finished', $batch_status['status'] );
 	}
 
@@ -427,12 +427,12 @@ class BatchTest extends \WP_UnitTestCase {
 			),
 		) );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertFalse( $batch_status );
 
 		$run = $post_batch->run( 1 );
 
-		$batch_status = get_site_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
+		$batch_status = get_option( $post_batch::BATCH_HOOK_PREFIX . $post_batch->slug );
 		$this->assertEquals( 'finished', $batch_status['status'] );
 	}
 


### PR DESCRIPTION
Resolves #33 

By using `XX_site_option` we set network wide options on multisite, and on single sites it will fallback to `XX_option()`.
