### PR TITLE
Refactor batch classes to reduce abstract class complexity

### DIFF
--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -82,6 +82,18 @@ abstract class Batch {
 	abstract function get_results();
 
 	/**
+	 * Calculate the offset for the current query.
+	 *
+	 * @param int $offset Offset value.
+	 */
+	public function calculate_offset( $offset ) {
+		if ( 1 !== $this->current_step ) {
+			// Example: step 2: 1 * 10 = offset of 10, step 3: 2 * 10 = offset of 20.
+			$this->args['offset'] = ( ( $this->current_step - 1 ) * $offset );
+		}
+	}
+
+	/**
 	 * Register the batch process so we can run it.
 	 *
 	 * @param  array $args Details about the batch you are registering.

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -92,14 +92,14 @@ abstract class Batch {
 	 *
 	 * @return array
 	 */
-	abstract public function individual_get_results();
+	abstract public function batch_get_results();
 
 	/**
 	 * Clear the result status for the registered batch process.
 	 *
 	 * @return bool
 	 */
-	abstract public function individual_clear_result_status();
+	abstract public function batch_clear_result_status();
 
 	/**
 	 * Get the result status for a given result item.
@@ -108,7 +108,7 @@ abstract class Batch {
 	 *
 	 * @return mixed
 	 */
-	abstract public function individual_get_result_status( $result );
+	abstract public function get_result_item_status( $result );
 
 	/**
 	 * Update the result status for a result item.
@@ -118,7 +118,7 @@ abstract class Batch {
 	 *
 	 * @return bool
 	 */
-	abstract public function individual_update_result_status( $result, $status );
+	abstract public function update_result_item_status( $result, $status );
 
 	/**
 	 * Main plugin method for querying data.
@@ -130,7 +130,7 @@ abstract class Batch {
 	public function get_results() {
 		$this->args = wp_parse_args( $this->args, $this->default_args );
 		$this->calculate_offset();
-		return $this->individual_get_results();
+		return $this->batch_get_results();
 	}
 
 	/**
@@ -365,7 +365,7 @@ abstract class Batch {
 		 */
 		do_action( 'loco_batch_' . $this->slug . '_update_result_status', $result, $status );
 
-		return $this->individual_update_result_status( $result, $status );
+		return $this->update_result_item_status( $result, $status );
 	}
 
 	/**
@@ -382,7 +382,7 @@ abstract class Batch {
 		 */
 		do_action( 'loco_batch_' . $this->slug . '_get_result_status', $result );
 
-		return $this->individual_get_result_status( $result );
+		return $this->get_result_item_status( $result );
 	}
 
 	/**
@@ -396,7 +396,7 @@ abstract class Batch {
 		 */
 		do_action( 'loco_batch_' . $this->slug . '_clear', $this );
 
-		$this->individual_clear_result_status();
+		$this->batch_clear_result_status();
 		$this->update_status( 'reset' );
 	}
 }

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -90,14 +90,14 @@ abstract class Batch {
 	/**
 	 * Get results function for the registered batch process.
 	 *
-	 * @return mixed
+	 * @return array
 	 */
 	abstract public function individual_get_results();
 
 	/**
 	 * Clear the result status for the registered batch process.
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
 	abstract public function individual_clear_result_status();
 
@@ -116,7 +116,7 @@ abstract class Batch {
 	 * @param mixed  $result The result we are updating the status of.
 	 * @param string $status The status to set.
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
 	abstract public function individual_update_result_status( $result, $status );
 

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -348,13 +348,7 @@ abstract class Batch {
 		 */
 		do_action( 'loco_batch_' . $this->slug . '_update_result_status', $result, $status );
 
-		if ( $result instanceof WP_Post ) {
-			update_post_meta( $result->ID, $this->slug . '_status', $status );
-		}
-
-		if ( $result instanceof WP_User ) {
-			update_user_meta( $result->data->ID, $this->slug . '_status', $status );
-		}
+		return $this->individual_update_result_status( $result, $status );
 	}
 
 	/**
@@ -397,11 +391,21 @@ abstract class Batch {
 	abstract public function individual_clear_result_status();
 
 	/**
-	 * Clear the result status for a given batch process.
+	 * Get the result status for a given batch process.
 	 *
 	 * @param mixed $result The result we are requesting status of.
 	 *
 	 * @return mixed
 	 */
 	abstract public function individual_get_result_status( $result );
+
+	/**
+	 * Update the result status for a given batch process.
+	 *
+	 * @param mixed  $result The result we are updating the status of.
+	 * @param string $status The status to set.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_update_result_status( $result, $status );
 }

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -114,12 +114,10 @@ abstract class Batch {
 				$query = new \WP_User_Query( $this->args );
 				$this->total_num_results = $query->get_total();
 				return $query->get_results();
-				break;
 			default:
 				$query = new \WP_Query( $this->args );
 				$this->total_num_results = $query->found_posts;
 				return $query->get_posts();
-				break;
 		}
 
 		return false;

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -109,18 +109,9 @@ abstract class Batch {
 	 * Calculate the offset for the current query.
 	 */
 	public function calculate_offset() {
-		switch ( $this->type ) {
-			case 'user':
-				$per_page_param = 'number';
-				break;
-			default:
-				$per_page_param = 'posts_per_page';
-				break;
-		}
-
 		if ( 1 !== $this->current_step ) {
 			// Example: step 2: 1 * 10 = offset of 10, step 3: 2 * 10 = offset of 20.
-			$this->args['offset'] = ( ( $this->current_step - 1 ) * $this->args[ $per_page_param ] );
+			$this->args['offset'] = ( ( $this->current_step - 1 ) * $this->args[ $this->per_batch_param ] );
 		}
 	}
 

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -393,17 +393,16 @@ abstract class Batch {
 		 *
 		 * @param Batch $this The current batch object.
 		 */
-		do_action( 'loco_batch_' . $this->slug. '_clear', $this );
+		do_action( 'loco_batch_' . $this->slug . '_clear', $this );
 
-		switch ( $this->type ) {
-			case 'post':
-				delete_post_meta_by_key( $this->slug . '_status' );
-				break;
-			case 'user':
-				delete_metadata( 'user', null, $this->slug . '_status', '', true );
-				break;
-		}
-
+		$this->individual_clear_result_status();
 		$this->update_status( 'reset' );
 	}
+
+	/**
+	 * Clear the result status for a given batch process.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_clear_result_status();
 }

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -373,7 +373,7 @@ abstract class Batch {
 	 *
 	 * @param mixed $result The result we want to get status of.
 	 */
-	private function get_result_status( $result ) {
+	public function get_result_status( $result ) {
 		/**
 		 * Action to hook into when a result is being checked for whether or not
 		 * it was updated.

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -83,14 +83,44 @@ abstract class Batch {
 
 	/**
 	 * Calculate the offset for the current query.
-	 *
-	 * @param int $offset Offset value.
 	 */
-	public function calculate_offset( $offset ) {
+	public function calculate_offset() {
+		switch ( $this->type ) {
+			case 'user':
+				$per_page_param = 'number';
+				break;
+			default:
+				$per_page_param = 'posts_per_page';
+				break;
+		}
+
 		if ( 1 !== $this->current_step ) {
 			// Example: step 2: 1 * 10 = offset of 10, step 3: 2 * 10 = offset of 20.
-			$this->args['offset'] = ( ( $this->current_step - 1 ) * $offset );
+			$this->args['offset'] = ( ( $this->current_step - 1 ) * $this->args[ $per_page_param ] );
 		}
+	}
+
+	/**
+	 * Base function for getting results. Relies on a properties set on `$this` to correctly
+	 * calculate query and query options.
+	 *
+	 * @return mixed
+	 */
+	public function base_get_results() {
+		$this->calculate_offset();
+
+		switch ( $this->type ) {
+			case 'post':
+				$query = new \WP_Query( $this->args );
+				break;
+			case 'user':
+				$query = new \WP_User_Query( $this->args );
+				break;
+		}
+
+		$this->total_num_results = $query->get_total();
+
+		return $query->get_results();
 	}
 
 	/**

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -371,17 +371,7 @@ abstract class Batch {
 		 */
 		do_action( 'loco_batch_' . $this->slug . '_get_result_status', $result );
 
-		$result_status = '';
-
-		if ( $result instanceof WP_Post ) {
-			$result_status = get_post_meta( $result->ID, $this->slug . '_status', true );
-		}
-
-		if ( $result instanceof WP_User ) {
-			$result_status = get_user_meta( $result->data->ID, $this->slug . '_status', true );
-		}
-
-		return $result_status;
+		return $this->individual_get_result_status( $result );
 	}
 
 	/**
@@ -405,4 +395,13 @@ abstract class Batch {
 	 * @return mixed
 	 */
 	abstract public function individual_clear_result_status();
+
+	/**
+	 * Clear the result status for a given batch process.
+	 *
+	 * @param mixed $result The result we are requesting status of.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_get_result_status( $result );
 }

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -28,6 +28,15 @@ abstract class Batch {
 	public $slug;
 
 	/**
+	 * The individual batch's parameter for specifying the amount of results to return.
+	 *
+	 * Can / should be overwritten within the class that extends this abstract class.
+	 *
+	 * @var string
+	 */
+	public $per_batch_param = 'posts_per_page';
+
+	/**
 	 * Args for the batch query.
 	 *
 	 * @var array
@@ -241,10 +250,8 @@ abstract class Batch {
 		$this->process_results( $results );
 
 		$per_page = get_option( 'posts_per_page' );
-		if ( isset( $this->args['posts_per_page'] ) ) {
-			$per_page = $this->args['posts_per_page'];
-		} else if ( $this->args['number'] ) {
-			$per_page = $this->args['number'];
+		if ( isset( $this->per_batch_param ) ) {
+			$per_page = $this->args[ $this->per_batch_param ];
 		}
 
 		/**

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -110,15 +110,15 @@ abstract class Batch {
 		$this->calculate_offset();
 
 		switch ( $this->type ) {
-			case 'post':
-				$query = new \WP_Query( $this->args );
-				$this->total_num_results = $query->found_posts;
-				return $query->get_posts();
-				break;
 			case 'user':
 				$query = new \WP_User_Query( $this->args );
 				$this->total_num_results = $query->get_total();
 				return $query->get_results();
+				break;
+			default:
+				$query = new \WP_Query( $this->args );
+				$this->total_num_results = $query->found_posts;
+				return $query->get_posts();
 				break;
 		}
 

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -112,15 +112,17 @@ abstract class Batch {
 		switch ( $this->type ) {
 			case 'post':
 				$query = new \WP_Query( $this->args );
+				$this->total_num_results = $query->found_posts;
+				return $query->get_posts();
 				break;
 			case 'user':
 				$query = new \WP_User_Query( $this->args );
+				$this->total_num_results = $query->get_total();
+				return $query->get_results();
 				break;
 		}
 
-		$this->total_num_results = $query->get_total();
-
-		return $query->get_results();
+		return false;
 	}
 
 	/**

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -8,8 +8,6 @@
 namespace Rkv\Locomotive\Abstracts;
 
 use Exception;
-use WP_Post;
-use WP_User;
 
 /**
  * Abstract batch class.

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -81,6 +81,39 @@ abstract class Batch {
 	public $total_num_results;
 
 	/**
+	 * Get results function for the registered batch process.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_get_results();
+
+	/**
+	 * Clear the result status for the registered batch process.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_clear_result_status();
+
+	/**
+	 * Get the result status for a given result item.
+	 *
+	 * @param mixed $result The result we are requesting status of.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_get_result_status( $result );
+
+	/**
+	 * Update the result status for a result item.
+	 *
+	 * @param mixed  $result The result we are updating the status of.
+	 * @param string $status The status to set.
+	 *
+	 * @return mixed
+	 */
+	abstract public function individual_update_result_status( $result, $status );
+
+	/**
 	 * Main plugin method for querying data.
 	 *
 	 * @since 0.1
@@ -90,19 +123,7 @@ abstract class Batch {
 	public function get_results() {
 		$this->args = wp_parse_args( $this->args, $this->default_args );
 		$this->calculate_offset();
-
-		switch ( $this->type ) {
-			case 'user':
-				$query = new \WP_User_Query( $this->args );
-				$this->total_num_results = $query->get_total();
-				return $query->get_results();
-			default:
-				$query = new \WP_Query( $this->args );
-				$this->total_num_results = $query->found_posts;
-				return $query->get_posts();
-		}
-
-		return false;
+		return $this->individual_get_results();
 	}
 
 	/**
@@ -373,30 +394,4 @@ abstract class Batch {
 		$this->individual_clear_result_status();
 		$this->update_status( 'reset' );
 	}
-
-	/**
-	 * Clear the result status for a given batch process.
-	 *
-	 * @return mixed
-	 */
-	abstract public function individual_clear_result_status();
-
-	/**
-	 * Get the result status for a given batch process.
-	 *
-	 * @param mixed $result The result we are requesting status of.
-	 *
-	 * @return mixed
-	 */
-	abstract public function individual_get_result_status( $result );
-
-	/**
-	 * Update the result status for a given batch process.
-	 *
-	 * @param mixed  $result The result we are updating the status of.
-	 * @param string $status The status to set.
-	 *
-	 * @return mixed
-	 */
-	abstract public function individual_update_result_status( $result, $status );
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -24,4 +24,8 @@ class Posts extends Batch {
 		'posts_per_page' => 10,
 		'offset'         => 0,
 	);
+
+	public function individual_clear_result_status() {
+		delete_post_meta_by_key( $this->slug . '_status' );
+	}
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -14,28 +14,59 @@ use Rkv\Locomotive\Abstracts\Batch;
  * Batch Posts class.
  */
 class Posts extends Batch {
+	/**
+	 * The individual batch's parameter for specifying the amount of results to return.
+	 *
+	 * @var string
+	 */
 	public $per_batch_param = 'posts_per_page';
 
+	/**
+	 * Default args for the query.
+	 *
+	 * @var array
+	 */
 	public $default_args = array(
 		'post_type'      => 'post',
 		'posts_per_page' => 10,
 		'offset'         => 0,
 	);
 
+	/**
+	 * Get results function for the registered batch process.
+	 *
+	 * @return array \WP_Query->get_posts() result.
+	 */
 	public function individual_get_results() {
 		$query = new WP_Query( $this->args );
 		$this->total_num_results = $query->found_posts;
 		return $query->get_posts();
 	}
 
+	/**
+	 * Clear the result status for a batch.
+	 *
+	 * @return bool
+	 */
 	public function individual_clear_result_status() {
 		return delete_post_meta_by_key( $this->slug . '_status' );
 	}
 
+	/**
+	 * Get the status of a result.
+	 *
+	 * @param \WP_Post $result The result we want to get status of.
+	 */
 	public function individual_get_result_status( $result ) {
 		return get_post_meta( $result->ID, $this->slug . '_status', true );
 	}
 
+	/**
+	 * Update the meta info on a result.
+	 *
+	 * @param \WP_Post $result  The result we want to track meta data on.
+	 * @param string   $status  Status of this result in the batch.
+	 */
 	public function individual_update_result_status( $result, $status ) {
 		return update_post_meta( $result->ID, $this->slug . '_status', $status );
 	}

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -15,15 +15,13 @@ use Rkv\Locomotive\Abstracts\Batch;
  */
 class Posts extends Batch {
 	/**
-	 * Get the results of the query.
+	 * Default arguments for this batch.
+	 *
+	 * @var array
 	 */
-	public function get_results() {
-		$this->args = wp_parse_args( $this->args, array(
-			'post_type'      => 'post',
-			'posts_per_page' => get_option( 'posts_per_page' ),
-			'offset'         => 0,
-		) );
-
-		return $this->base_get_results();
-	}
+	public $default_args = array(
+		'post_type'      => 'post',
+		'posts_per_page' => 10,
+		'offset'         => 0,
+	);
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -14,6 +14,8 @@ use Rkv\Locomotive\Abstracts\Batch;
  * Batch Posts class.
  */
 class Posts extends Batch {
+	public $per_batch_param = 'posts_per_page';
+
 	public $default_args = array(
 		'post_type'      => 'post',
 		'posts_per_page' => 10,

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -37,7 +37,7 @@ class Posts extends Batch {
 	 *
 	 * @return array \WP_Query->get_posts() result.
 	 */
-	public function individual_get_results() {
+	public function batch_get_results() {
 		$query = new WP_Query( $this->args );
 		$this->total_num_results = $query->found_posts;
 		return $query->get_posts();
@@ -48,7 +48,7 @@ class Posts extends Batch {
 	 *
 	 * @return bool
 	 */
-	public function individual_clear_result_status() {
+	public function batch_clear_result_status() {
 		return delete_post_meta_by_key( $this->slug . '_status' );
 	}
 
@@ -57,7 +57,7 @@ class Posts extends Batch {
 	 *
 	 * @param \WP_Post $result The result we want to get status of.
 	 */
-	public function individual_get_result_status( $result ) {
+	public function get_result_item_status( $result ) {
 		return get_post_meta( $result->ID, $this->slug . '_status', true );
 	}
 
@@ -67,7 +67,7 @@ class Posts extends Batch {
 	 * @param \WP_Post $result  The result we want to track meta data on.
 	 * @param string   $status  Status of this result in the batch.
 	 */
-	public function individual_update_result_status( $result, $status ) {
+	public function update_result_item_status( $result, $status ) {
 		return update_post_meta( $result->ID, $this->slug . '_status', $status );
 	}
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -22,6 +22,12 @@ class Posts extends Batch {
 		'offset'         => 0,
 	);
 
+	public function individual_get_results() {
+		$query = new \WP_Query( $this->args );
+		$this->total_num_results = $query->found_posts;
+		return $query->get_posts();
+	}
+
 	public function individual_clear_result_status() {
 		return delete_post_meta_by_key( $this->slug . '_status' );
 	}

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -25,7 +25,23 @@ class Posts extends Batch {
 		'offset'         => 0,
 	);
 
+	/**
+	 * Clear the result status for the registered batch process.
+	 *
+	 * @return mixed
+	 */
 	public function individual_clear_result_status() {
 		delete_post_meta_by_key( $this->slug . '_status' );
+	}
+
+	/**
+	 * Get the status for an individual result for the registered batch process.
+	 *
+	 * @param mixed $result The result we are requesting status of.
+	 *
+	 * @return mixed
+	 */
+	public function individual_get_result_status( $result ) {
+		return get_post_meta( $result->ID, $this->slug . '_status', true );
 	}
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -18,20 +18,12 @@ class Posts extends Batch {
 	 * Get the results of the query.
 	 */
 	public function get_results() {
-		// Set some defaults.
 		$this->args = wp_parse_args( $this->args, array(
 			'post_type'      => 'post',
 			'posts_per_page' => get_option( 'posts_per_page' ),
 			'offset'         => 0,
 		) );
 
-		$this->calculate_offset( $this->args['posts_per_page'] );
-
-		$query = new WP_Query( $this->args );
-
-		// Update the batch object with the total num of results found.
-		$this->total_num_results = $query->found_posts;
-
-		return $query->get_posts();
+		return $this->base_get_results();
 	}
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -23,7 +23,7 @@ class Posts extends Batch {
 	);
 
 	public function individual_get_results() {
-		$query = new \WP_Query( $this->args );
+		$query = new WP_Query( $this->args );
 		$this->total_num_results = $query->found_posts;
 		return $query->get_posts();
 	}

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -14,34 +14,21 @@ use Rkv\Locomotive\Abstracts\Batch;
  * Batch Posts class.
  */
 class Posts extends Batch {
-	/**
-	 * Default arguments for this batch.
-	 *
-	 * @var array
-	 */
 	public $default_args = array(
 		'post_type'      => 'post',
 		'posts_per_page' => 10,
 		'offset'         => 0,
 	);
 
-	/**
-	 * Clear the result status for the registered batch process.
-	 *
-	 * @return bool
-	 */
 	public function individual_clear_result_status() {
 		return delete_post_meta_by_key( $this->slug . '_status' );
 	}
 
-	/**
-	 * Get the status for an individual result for the registered batch process.
-	 *
-	 * @param mixed $result The result we are requesting status of.
-	 *
-	 * @return mixed
-	 */
 	public function individual_get_result_status( $result ) {
 		return get_post_meta( $result->ID, $this->slug . '_status', true );
+	}
+
+	public function individual_update_result_status( $result, $status ) {
+		return update_post_meta( $result->ID, $this->slug . '_status', $status );
 	}
 }

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -28,10 +28,10 @@ class Posts extends Batch {
 	/**
 	 * Clear the result status for the registered batch process.
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
 	public function individual_clear_result_status() {
-		delete_post_meta_by_key( $this->slug . '_status' );
+		return delete_post_meta_by_key( $this->slug . '_status' );
 	}
 
 	/**

--- a/includes/batches/class-batch-posts.php
+++ b/includes/batches/class-batch-posts.php
@@ -25,10 +25,7 @@ class Posts extends Batch {
 			'offset'         => 0,
 		) );
 
-		if ( 1 !== $this->current_step ) {
-			// Example: step 2: 1 * 10 = offset of 10, step 3: 2 * 10 = offset of 20.
-			$this->args['offset'] = ( ( $this->current_step - 1 ) * $this->args['posts_per_page'] );
-		}
+		$this->calculate_offset( $this->args['posts_per_page'] );
 
 		$query = new WP_Query( $this->args );
 

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -14,33 +14,20 @@ use Rkv\Locomotive\Abstracts\Batch;
  * Batch Users class.
  */
 class Users extends Batch {
-	/**
-	 * Default arguments for this batch.
-	 *
-	 * @var array
-	 */
 	public $default_args = array(
 		'number' => 10,
 		'offset' => 0,
 	);
 
-	/**
-	 * Clear the result status for the registered batch process.
-	 *
-	 * @return bool
-	 */
 	public function individual_clear_result_status() {
 		return delete_metadata( 'user', null, $this->slug . '_status', '', true );
 	}
 
-	/**
-	 * Get the status for an individual result for the registered batch process.
-	 *
-	 * @param mixed $result The result we are requesting status of.
-	 *
-	 * @return mixed
-	 */
 	public function individual_get_result_status( $result ) {
 		return get_user_meta( $result->data->ID, $this->slug . '_status', true );
+	}
+
+	public function individual_update_result_status( $result, $status ) {
+		return update_user_meta( $result->data->ID, $this->slug . '_status', $status );
 	}
 }

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -23,4 +23,8 @@ class Users extends Batch {
 		'number' => 10,
 		'offset' => 0,
 	);
+
+	public function individual_clear_result_status() {
+		delete_metadata( 'user', null, $this->slug . '_status', '', true );
+	}
 }

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -22,7 +22,7 @@ class Users extends Batch {
 	);
 
 	public function individual_get_results() {
-		$query = new \WP_User_Query( $this->args );
+		$query = new WP_User_Query( $this->args );
 		$this->total_num_results = $query->get_total();
 		return $query->get_results();
 	}

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -14,6 +14,8 @@ use Rkv\Locomotive\Abstracts\Batch;
  * Batch Users class.
  */
 class Users extends Batch {
+	public $per_batch_param = 'number';
+
 	public $default_args = array(
 		'number' => 10,
 		'offset' => 0,

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -15,14 +15,12 @@ use Rkv\Locomotive\Abstracts\Batch;
  */
 class Users extends Batch {
 	/**
-	 * Get the results of the query.
+	 * Default arguments for this batch.
+	 *
+	 * @var array
 	 */
-	public function get_results() {
-		$this->args = wp_parse_args( $this->args, array(
-			'number' => 10,
-			'offset' => 0,
-		) );
-
-		return $this->base_get_results();
-	}
+	public $default_args = array(
+		'number' => 10,
+		'offset' => 0,
+	);
 }

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -27,10 +27,10 @@ class Users extends Batch {
 	/**
 	 * Clear the result status for the registered batch process.
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
 	public function individual_clear_result_status() {
-		delete_metadata( 'user', null, $this->slug . '_status', '', true );
+		return delete_metadata( 'user', null, $this->slug . '_status', '', true );
 	}
 
 	/**

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -36,7 +36,7 @@ class Users extends Batch {
 	 *
 	 * @return array \WP_User_query->get_results() result.
 	 */
-	public function individual_get_results() {
+	public function batch_get_results() {
 		$query = new WP_User_Query( $this->args );
 		$this->total_num_results = $query->get_total();
 		return $query->get_results();
@@ -47,7 +47,7 @@ class Users extends Batch {
 	 *
 	 * @return bool
 	 */
-	public function individual_clear_result_status() {
+	public function batch_clear_result_status() {
 		return delete_metadata( 'user', null, $this->slug . '_status', '', true );
 	}
 
@@ -56,7 +56,7 @@ class Users extends Batch {
 	 *
 	 * @param \WP_User $result The result we want to get status of.
 	 */
-	public function individual_get_result_status( $result ) {
+	public function get_result_item_status( $result ) {
 		return get_user_meta( $result->data->ID, $this->slug . '_status', true );
 	}
 
@@ -66,7 +66,7 @@ class Users extends Batch {
 	 * @param \WP_User $result  The result we want to track meta data on.
 	 * @param string   $status  Status of this result in the batch.
 	 */
-	public function individual_update_result_status( $result, $status ) {
+	public function update_result_item_status( $result, $status ) {
 		return update_user_meta( $result->data->ID, $this->slug . '_status', $status );
 	}
 }

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -24,7 +24,23 @@ class Users extends Batch {
 		'offset' => 0,
 	);
 
+	/**
+	 * Clear the result status for the registered batch process.
+	 *
+	 * @return mixed
+	 */
 	public function individual_clear_result_status() {
 		delete_metadata( 'user', null, $this->slug . '_status', '', true );
+	}
+
+	/**
+	 * Get the status for an individual result for the registered batch process.
+	 *
+	 * @param mixed $result The result we are requesting status of.
+	 *
+	 * @return mixed
+	 */
+	public function individual_get_result_status( $result ) {
+		return get_user_meta( $result->data->ID, $this->slug . '_status', true );
 	}
 }

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -18,19 +18,11 @@ class Users extends Batch {
 	 * Get the results of the query.
 	 */
 	public function get_results() {
-		// Set some defaults.
 		$this->args = wp_parse_args( $this->args, array(
 			'number' => 10,
 			'offset' => 0,
 		) );
 
-		$this->calculate_offset( $this->args['number'] );
-
-		$query = new WP_User_Query( $this->args );
-
-		// Update the batch object with the total num of results found.
-		$this->total_num_results = $query->get_total();
-
-		return $query->get_results();
+		return $this->base_get_results();
 	}
 }

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -14,27 +14,58 @@ use Rkv\Locomotive\Abstracts\Batch;
  * Batch Users class.
  */
 class Users extends Batch {
+	/**
+	 * The individual batch's parameter for specifying the amount of results to return.
+	 *
+	 * @var string
+	 */
 	public $per_batch_param = 'number';
 
+	/**
+	 * Default args for the query.
+	 *
+	 * @var array
+	 */
 	public $default_args = array(
 		'number' => 10,
 		'offset' => 0,
 	);
 
+	/**
+	 * Get results function for the registered batch process.
+	 *
+	 * @return array \WP_User_query->get_results() result.
+	 */
 	public function individual_get_results() {
 		$query = new WP_User_Query( $this->args );
 		$this->total_num_results = $query->get_total();
 		return $query->get_results();
 	}
 
+	/**
+	 * Clear the result status for a batch.
+	 *
+	 * @return bool
+	 */
 	public function individual_clear_result_status() {
 		return delete_metadata( 'user', null, $this->slug . '_status', '', true );
 	}
 
+	/**
+	 * Get the status of a result.
+	 *
+	 * @param \WP_User $result The result we want to get status of.
+	 */
 	public function individual_get_result_status( $result ) {
 		return get_user_meta( $result->data->ID, $this->slug . '_status', true );
 	}
 
+	/**
+	 * Update the meta info on a result.
+	 *
+	 * @param \WP_User $result  The result we want to track meta data on.
+	 * @param string   $status  Status of this result in the batch.
+	 */
 	public function individual_update_result_status( $result, $status ) {
 		return update_user_meta( $result->data->ID, $this->slug . '_status', $status );
 	}

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -24,10 +24,7 @@ class Users extends Batch {
 			'offset' => 0,
 		) );
 
-		if ( 1 !== $this->current_step ) {
-			// Example: step 2: 1 * 10 = offset of 10, step 3: 2 * 10 = offset of 20.
-			$this->args['offset'] = ( ( $this->current_step - 1 ) * $this->args['number'] );
-		}
+		$this->calculate_offset( $this->args['number'] );
 
 		$query = new WP_User_Query( $this->args );
 

--- a/includes/batches/class-batch-users.php
+++ b/includes/batches/class-batch-users.php
@@ -21,6 +21,12 @@ class Users extends Batch {
 		'offset' => 0,
 	);
 
+	public function individual_get_results() {
+		$query = new \WP_User_Query( $this->args );
+		$this->total_num_results = $query->get_total();
+		return $query->get_results();
+	}
+
 	public function individual_clear_result_status() {
 		return delete_metadata( 'user', null, $this->slug . '_status', '', true );
 	}


### PR DESCRIPTION
Related to #61 

This is a WIP 'proposal' type of PR. I definitely went out on a bit of a limb and refactored the way that child classes of `Batch` are implemented.

My thought process while working on this was that I wanted to make the extension of the `Batch` class as straightforward as possible. Previously, we just relied on the singular `get_results()` function to be implemented on each child class. I think that approach isn't ideal because it puts a lot of responsibility on that singular function (it was setting args in addition to running the query).

I think the current approach outlined in this PR has a better separation of concerns which removes some of the complexity from the base abstract class. Rather than relying on multiple `switch` statements that would grow as we added the additional batch process types ( #42 ), we instead force the child classes to define these functions themselves.

I'm excited to get some feedback (even if it ends up being that this approach isn't ideal) so please don't hesitate to share your thoughts :)

PS: Was able to refactor this relatively easily thanks to all of our unit tests! Hooray for those 🎉 