### PR TITLE
Adds WP_Term_Query support

### DIFF
--- a/includes/batches/class-batch-terms.php
+++ b/includes/batches/class-batch-terms.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Users batch class.
+ *
+ * @package Locomotive/Batch
+ */
+
+namespace Rkv\Locomotive\Batches;
+
+use WP_Term_Query;
+use Rkv\Locomotive\Abstracts\Batch;
+
+/**
+ * Batch Users class.
+ */
+class Terms extends Batch {
+	/**
+	 * The individual batch's parameter for specifying the amount of results to return.
+	 *
+	 * @var string
+	 */
+	public $per_batch_param = 'number';
+
+	/**
+	 * Default args for the query.
+	 *
+	 * @var array
+	 */
+	public $default_args = array(
+		'number' => 10,
+		'offset' => 0,
+	);
+
+	/**
+	 * Get results function for the registered batch process.
+	 *
+	 * @return array \WP_Term_Query->get_results() result.
+	 */
+	public function batch_get_results() {
+		$query = new WP_Term_Query( $this->args );
+
+		// Need to do a count query in order to get all possible terms as an integer.
+		$count_args = wp_parse_args( array( 'fields' => 'count', 'offset' => 0 ), $this->args );
+		$count = new WP_Term_query( $count_args );
+		$this->total_num_results = $count->get_terms();
+
+		return $query->get_terms();
+	}
+
+	/**
+	 * Clear the result status for a batch.
+	 *
+	 * @return bool
+	 */
+	public function batch_clear_result_status() {
+		return delete_metadata( 'term', null, $this->slug . '_status', '', true );
+	}
+
+	/**
+	 * Get the status of a result.
+	 *
+	 * @param \WP_Term $result The result we want to get status of.
+	 */
+	public function get_result_item_status( $result ) {
+		return get_term_meta( $result->data->term_id, $this->slug . '_status', true );
+	}
+
+	/**
+	 * Update the meta info on a result.
+	 *
+	 * @param \WP_Term $result  The result we want to track meta data on.
+	 * @param string   $status  Status of this result in the batch.
+	 */
+	public function update_result_item_status( $result, $status ) {
+		return update_term_meta( $result->data->term_id, $this->slug . '_status', $status );
+	}
+}

--- a/includes/batches/class-batch-terms.php
+++ b/includes/batches/class-batch-terms.php
@@ -41,7 +41,7 @@ class Terms extends Batch {
 
 		// Need to do a count query in order to get all possible terms as an integer.
 		$count_args = wp_parse_args( array( 'fields' => 'count', 'offset' => 0 ), $this->args );
-		$count = new WP_Term_query( $count_args );
+		$count = new WP_Term_Query( $count_args );
 		$this->total_num_results = $count->get_terms();
 
 		return $query->get_terms();

--- a/includes/batches/class-batch-terms.php
+++ b/includes/batches/class-batch-terms.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Users batch class.
+ * Terms batch class.
  *
  * @package Locomotive/Batch
  */
@@ -11,7 +11,7 @@ use WP_Term_Query;
 use Rkv\Locomotive\Abstracts\Batch;
 
 /**
- * Batch Users class.
+ * Batch Term class.
  */
 class Terms extends Batch {
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,6 +8,7 @@
 use Rkv\Locomotive\Abstracts\Batch;
 use Rkv\Locomotive\Batches\Posts;
 use Rkv\Locomotive\Batches\Users;
+use Rkv\Locomotive\Batches\Terms;
 
 /**
  * Register a new batch process.
@@ -28,6 +29,11 @@ function register_batch_process( $args ) {
 
 		case 'user':
 			$batch_process = new Users();
+			$batch_process->register( $args );
+			break;
+
+		case 'term':
+			$batch_process = new Terms();
 			$batch_process->register( $args );
 			break;
 	}

--- a/locomotive.php
+++ b/locomotive.php
@@ -62,6 +62,7 @@ final class Loader {
 		require_once( LOCO_PLUGIN_DIR . 'includes/abstracts/abstract-batch.php' );
 		require_once( LOCO_PLUGIN_DIR . 'includes/batches/class-batch-posts.php' );
 		require_once( LOCO_PLUGIN_DIR . 'includes/batches/class-batch-users.php' );
+		require_once( LOCO_PLUGIN_DIR . 'includes/batches/class-batch-terms.php' );
 		require_once( LOCO_PLUGIN_DIR . 'includes/functions.php' );
 	}
 

--- a/tests/test-batch.php
+++ b/tests/test-batch.php
@@ -5,6 +5,7 @@ namespace Rkv\Locomotive\Tests;
 use WP_UnitTestCase;
 use Rkv\Locomotive\Batches\Posts;
 use Rkv\Locomotive\Batches\Users;
+use Rkv\Locomotive\Batches\Terms;
 
 class BatchTest extends WP_UnitTestCase {
 	/**
@@ -251,6 +252,46 @@ class BatchTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that term batch gets run.
+	 */
+	public function test_term_finished_run() {
+		$terms = $this->factory->category->create_many( 5 );
+
+		$term_batch = new Terms();
+
+		$term_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'term',
+			'callback' => __NAMESPACE__ . '\\my_term_callback_function_test',
+			'args'     => array(
+				'number' => 10,
+				'taxonomy' => 'category',
+				'hide_empty' => false,
+			),
+		) );
+
+		$batch_status = get_option( 'loco_batch_' . $term_batch->slug );
+		$this->assertFalse( $batch_status );
+
+		$run = $term_batch->run( 1 );
+
+		$batch_status = get_option( 'loco_batch_' . $term_batch->slug );
+		$this->assertEquals( 'finished', $batch_status['status'] );
+
+		// Loop through each post and make sure our value was set.
+		foreach ( $terms as $term ) {
+			$meta = get_term_meta( $term, 'custom-key', true );
+			$this->assertEquals( 'my-value', $meta );
+
+			$status = get_term_meta( $term, $term_batch->slug . '_status', true );
+			$this->assertEquals( 'success', $status );
+		}
+
+		// Run again so it skips some.
+		$run = $term_batch->run( 1 );
+	}
+
+	/**
 	 * Test that you can clear individual result status.
 	 */
 	public function test_clear_result_status() {
@@ -325,6 +366,42 @@ class BatchTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that you can clear individual result status.
+	 */
+	public function test_clear_term_result_status() {
+		$terms = $this->factory->tag->create_many( 5 );
+
+		$term_batch = new Terms();
+
+		$term_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'term',
+			'callback' => __NAMESPACE__ . '\\my_term_callback_function_test',
+			'args'     => array(
+				'number' => 7,
+				'taxonomy' => 'post_tag',
+				'hide_empty' => false,
+			),
+		) );
+
+		$run = $term_batch->run( 1 );
+
+		$term_batch->clear_result_status();
+
+		// Loop through each post and make sure our value was set.
+		foreach ( $terms as $term ) {
+			$meta = get_term_meta( $term, 'custom-key', true );
+			$this->assertEquals( 'my-value', $meta );
+
+			$status = get_term_meta( $term, $term_batch->slug . '_status', true );
+			$this->assertEquals( '', $status );
+		}
+
+		$batches = locomotive_get_all_batches();
+		$this->assertEquals( 'reset', $batches['hey-there']['status'] );
+	}
+
+	/**
 	 * Test that batch gets run.
 	 */
 	public function test_running_run() {
@@ -380,6 +457,34 @@ class BatchTest extends WP_UnitTestCase {
 		$run = $post_batch->run( 2 );
 
 		$batch_status = get_option( 'loco_batch_' . $post_batch->slug );
+		$this->assertEquals( 'finished', $batch_status['status'] );
+	}
+
+	/**
+	 * Test that terms offset batch gets run.
+	 */
+	public function test_terms_offset_run() {
+		$users = $this->factory->category->create_many( 8 );
+
+		$term_batch = new Terms();
+		$term_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'term',
+			'callback' => 'my_callback_function_test',
+			'args'     => array(
+				'number' => 5,
+				'offset' => 5,
+				'taxonomy' => 'category',
+				'hide_empty' => false,
+			),
+		) );
+
+		$batch_status = get_option( 'loco_batch_' . $term_batch->slug );
+		$this->assertFalse( $batch_status );
+
+		$run = $term_batch->run( 2 );
+
+		$batch_status = get_option( 'loco_batch_' . $term_batch->slug );
 		$this->assertEquals( 'finished', $batch_status['status'] );
 	}
 
@@ -482,6 +587,15 @@ function my_user_callback_function_test( $result ) {
 }
 
 /**
+ * My callback function test for terms.
+ *
+ * @param WP_Term $result Result item.
+ */
+function my_term_callback_function_test( $result ) {
+	update_term_meta( $result->data->term_id, 'custom-key', 'my-value' );
+}
+
+/**
  * My callback function test.
  *
  * @throws Exception Not worknig.
@@ -489,4 +603,3 @@ function my_user_callback_function_test( $result ) {
 function my_callback_function_test_false() {
 	throw new Exception( 'Not working' );
 }
-


### PR DESCRIPTION
Creates a class for terms, and sets default parameters there. The one difference from the other classes is that we need to perform an extra count query in order to get the total count (equivalent of found_posts or get_total, neither of which exist for WP_Term_Query)