### PR TITLE
Add WP_Site_Query support

### DIFF
--- a/includes/batches/class-batch-sites.php
+++ b/includes/batches/class-batch-sites.php
@@ -29,7 +29,7 @@ class Sites extends Batch {
 	public $default_args = array(
 		'number' => 10,
 		'offset' => 0,
-		'no_found_rows' => false
+		'no_found_rows' => false,
 	);
 
 	/**

--- a/includes/batches/class-batch-sites.php
+++ b/includes/batches/class-batch-sites.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Sites batch class.
+ *
+ * @package Locomotive/Batch
+ */
+
+namespace Rkv\Locomotive\Batches;
+
+use WP_Site_Query;
+use Rkv\Locomotive\Abstracts\Batch;
+
+/**
+ * Batch Sites class.
+ */
+class Sites extends Batch {
+	/**
+	 * The individual batch's parameter for specifying the amount of results to return.
+	 *
+	 * @var string
+	 */
+	public $per_batch_param = 'number';
+
+	/**
+	 * Default args for the query.
+	 *
+	 * @var array
+	 */
+	public $default_args = array(
+		'number' => 10,
+		'offset' => 0,
+		'no_found_rows' => false
+	);
+
+	/**
+	 * Get results function for the registered batch process.
+	 *
+	 * @return array \WP_Site_Query->get_results() result.
+	 */
+	public function batch_get_results() {
+		$query = new WP_Site_Query( $this->args );
+		$this->total_num_results = $query->found_sites;
+		return $query->get_sites();
+	}
+
+	/**
+	 * Clear the result status for a batch.
+	 *
+	 * @return bool
+	 */
+	public function batch_clear_result_status() {
+		return delete_metadata( 'site', null, $this->slug . '_status', '', true );
+	}
+
+	/**
+	 * Get the status of a result.
+	 *
+	 * @param \WP_Site $result The result we want to get status of.
+	 */
+	public function get_result_item_status( $result ) {
+		return get_metadata( 'site', $result->blog_id, $this->slug . '_status', true );
+	}
+
+	/**
+	 * Update the meta info on a result.
+	 *
+	 * @param \WP_Site $result  The result we want to track meta data on.
+	 * @param string   $status  Status of this result in the batch.
+	 */
+	public function update_result_item_status( $result, $status ) {
+		return update_metadata( 'site', $result->blog_id, $this->slug . '_status', $status );
+	}
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,6 +8,7 @@
 use Rkv\Locomotive\Abstracts\Batch;
 use Rkv\Locomotive\Batches\Posts;
 use Rkv\Locomotive\Batches\Users;
+use Rkv\Locomotive\Batches\Sites;
 
 /**
  * Register a new batch process.
@@ -30,6 +31,14 @@ function register_batch_process( $args ) {
 			$batch_process = new Users();
 			$batch_process->register( $args );
 			break;
+
+		case 'site':
+			if ( is_multisite() ) {
+				$batch_process = new Sites();
+				$batch_process->register( $args );
+			}
+			break;
+
 	}
 }
 

--- a/locomotive.php
+++ b/locomotive.php
@@ -62,6 +62,7 @@ final class Loader {
 		require_once( LOCO_PLUGIN_DIR . 'includes/abstracts/abstract-batch.php' );
 		require_once( LOCO_PLUGIN_DIR . 'includes/batches/class-batch-posts.php' );
 		require_once( LOCO_PLUGIN_DIR . 'includes/batches/class-batch-users.php' );
+		require_once( LOCO_PLUGIN_DIR . 'includes/batches/class-batch-sites.php' );
 		require_once( LOCO_PLUGIN_DIR . 'includes/functions.php' );
 	}
 

--- a/tests/types/test-batch-sites.php
+++ b/tests/types/test-batch-sites.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Rkv\Locomotive\Tests;
+
+use WP_UnitTestCase;
+use Rkv\Locomotive\Batches\Sites;
+
+class SiteBatchTest extends WP_UnitTestCase {
+	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		locomotive_clear_existing_batches();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->blogs = $this->factory->blog->create_many( 5 );
+		$this->user = $this->factory->user->create();
+	}
+
+	protected function checkRequirements() {
+		parent::checkRequirements();
+
+		$annotations = $this->getAnnotations();
+
+		foreach ( array( 'class', 'method' ) as $depth ) {
+			if ( empty( $annotations[ $depth ]['requires'] ) ) {
+				continue;
+			}
+
+			$requires = array_flip( $annotations[ $depth ]['requires'] );
+			if ( isset( $requires['Multisite'] ) && ! is_multisite() ) {
+				$this->markTestSkipped( 'Multisite must be enabled' );
+			}
+		}
+	}
+
+
+	/**
+	 * Test that site batch runs
+	 *
+	 * @requires Multisite
+	 */
+	public function test_site_finished_run() {
+		$site_batch = new Sites();
+
+		$site_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'site',
+			'callback' => __NAMESPACE__ . '\\my_site_callback_function_test',
+			'args'     => array(
+				'number' => 10,
+			),
+		) );
+
+		$batch_status = get_option( 'loco_batch_' . $site_batch->slug );
+		$this->assertFalse( $batch_status );
+
+		$run = $site_batch->run( 1 );
+
+		$batch_status = get_option( 'loco_batch_' . $site_batch->slug );
+		$this->assertEquals( 'finished', $batch_status['status'] );
+
+		// Loop through each post and make sure our value was set.
+		foreach ( $this->blogs as $site ) {
+			$meta = get_metadata( 'site', $site, 'custom-key', true );
+			$this->assertEquals( 'my-value', $meta );
+
+			$status = get_metadata( 'site', $site, $site_batch->slug . '_status', true );
+			$this->assertEquals( 'success', $status );
+		}
+
+		// Run again so it skips some.
+		$run = $site_batch->run( 1 );
+	}
+
+	/**
+	 * Test that you can clear individual result status.
+	 *
+	 * @requires Multisite
+	 */
+	public function test_clear_site_result_status() {
+		$site_batch = new Sites();
+
+		$site_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'site',
+			'callback' => __NAMESPACE__ . '\\my_site_callback_function_test',
+			'args'     => array(
+				'number' => 7,
+			),
+		) );
+
+		$run = $site_batch->run( 1 );
+
+		$site_batch->clear_result_status();
+
+		// Loop through each post and make sure our value was set.
+		foreach ( $this->blogs as $site ) {
+			$meta = get_metadata( 'site', $site, 'custom-key', true );
+			$this->assertEquals( 'my-value', $meta );
+
+			$status = get_metadata( 'site', $site, $site_batch->slug . '_status', true );
+			$this->assertEquals( '', $status );
+		}
+
+		$batches = locomotive_get_all_batches();
+		$this->assertEquals( 'reset', $batches['hey-there']['status'] );
+	}
+
+	/**
+	 * Test that users offset batch gets run.
+	 *
+	 * @requires Multisite
+	 */
+	public function test_users_offset_run() {
+		$site_batch = new Sites();
+
+		$site_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'site',
+			'callback' => __NAMESPACE__ . '\\my_site_callback_function_test',
+			'args'     => array(
+				'number' => 3,
+				'offset' => 3,
+			),
+		) );
+
+		$batch_status = get_option( 'loco_batch_' . $site_batch->slug );
+		$this->assertFalse( $batch_status );
+
+		$run = $site_batch->run( 2 );
+
+		$batch_status = get_option( 'loco_batch_' . $site_batch->slug );
+		$this->assertEquals( 'finished', $batch_status['status'] );
+	}
+
+}
+
+function my_site_callback_function_test( $result ) {
+	update_metadata( 'site', $result->blog_id, 'custom-key', 'my-value' );
+}


### PR DESCRIPTION
Adds support for WP_Site_Query. Need to do a check before the process is even registered to ensure that we are in a multisite WordPress install. If we are not, the process will not register or be shown in the backend.

Unit Tests have been added to their own file. I’ll refactor everything to be like this eventually, and this let me tweak the requirements for the unit tests to only run when Multisite is enabled.