### PR TITLE
Adds default array to args

### DIFF
--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -208,7 +208,7 @@ abstract class Batch {
 		}
 
 		if ( empty( $args['args'] ) || ! is_array( $args['args'] ) ) {
-			throw new Exception( __( 'An array of args must be defined.', 'locomotive' ) );
+			$this->args = array();
 		} else {
 			$this->args = $args['args'];
 		}

--- a/tests/test-batch.php
+++ b/tests/test-batch.php
@@ -3,9 +3,11 @@
 namespace Rkv\Locomotive\Tests;
 
 use WP_UnitTestCase;
+use Exception;
 use Rkv\Locomotive\Batches\Posts;
 use Rkv\Locomotive\Batches\Users;
 use Rkv\Locomotive\Batches\Terms;
+
 
 class BatchTest extends WP_UnitTestCase {
 	/**
@@ -18,79 +20,74 @@ class BatchTest extends WP_UnitTestCase {
 
 	/**
 	 * Test name is included.
-	 *
-	 * @expectedExceptionMessage Batch name must be provided.
 	 */
 	public function test_register_batch_includes_name() {
-		$this->setExpectedException( 'Exception' );
+		try {
+			$batch_process = new Posts();
+			$batch_process->register( array(
+				'slug'     => 'test-anot22h12er-batch',
+				'type'     => 'post',
+				'callback' => 'my_callback_function',
+				'args'     => array(
+					'posts_per_page' => 10,
+					'post_type'      => 'post',
+				),
+			) );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'Batch name must be defined.', $e->getMessage() );
+		}
 
-		$batch_process = new Posts();
-		$batch_process->register( array(
-			'slug'     => 'test-anot22h12er-batch',
-			'type'     => 'post',
-			'callback' => 'my_callback_function',
-			'args'     => array(
-				'posts_per_page' => 10,
-				'post_type'      => 'post',
-			),
-		) );
 	}
 
 	/**
-	 * Test name is included.
-	 *
-	 * @expectedExceptionMessage Type of batch must be defined.
+	 * Test type is included.
 	 */
 	public function test_register_batch_includes_type() {
-		$this->setExpectedException( 'Exception' );
-
-		$batch_process = new Posts();
-		$batch_process->register( array(
-			'name'     => 'Hey',
-			'slug'     => 'test-anot22h12er-batch',
-			'callback' => 'my_callback_function',
-			'args'     => array(
-				'posts_per_page' => 10,
-				'post_type'      => 'post',
-			),
-		) );
-	}
-
-	/**
-	 * Test array args is included.
-	 *
-	 * @expectedExceptionMessage An array of args must be defined.
-	 */
-	public function test_register_batch_includes_callback() {
-		$this->setExpectedException( 'Exception' );
-
-		$batch_process = new Posts();
-		$batch_process->register( array(
-			'name'     => 'Hey',
-			'type'     => 'post',
-			'slug'     => 'test-anot22h12er-batch',
-			'args'     => array(
-				'posts_per_page' => 10,
-				'post_type'      => 'post',
-			),
-		) );
+		try {
+			$batch_process = new Posts();
+			$batch_process->register( array(
+				'name'     => 'Hey',
+				'slug'     => 'test-anot22h12er-batch',
+				'callback' => 'my_callback_function',
+				'args'     => array(
+					'posts_per_page' => 10,
+					'post_type'      => 'post',
+				),
+			) );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'Batch type must be defined.', $e->getMessage() );
+		}
 	}
 
 	/**
 	 * Test callback defined
-	 *
-	 * @expectedExceptionMessage A callback must be defined.
 	 */
-	public function test_register_batch_includes_args() {
-		$this->setExpectedException( 'Exception' );
+	public function test_register_batch_includes_callback() {
+		try {
+			$batch_process = new Posts();
+			$batch_process->register( array(
+				'name'     => 'Hey',
+				'type'     => 'post',
+				'slug'     => 'test-anot22h12er-batch',
+				'args'     => 0,
+			) );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'A callback must be defined.', $e->getMessage() );
+		}
+	}
 
+	/**
+	 * Test without arguments
+	 */
+	public function test_register_batch_no_args() {
 		$batch_process = new Posts();
 		$batch_process->register( array(
-			'name'     => 'Hey',
+			'name'     => 'Hey there',
 			'type'     => 'post',
-			'slug'     => 'test-anot22h12er-batch',
-			'args'     => 0,
+			'callback' => 'my_callback_function',
 		) );
+
+			$this->assertNotNull( $batch_process->currently_registered['hey-there'] );
 	}
 
 	/**

--- a/tests/test-batch.php
+++ b/tests/test-batch.php
@@ -79,7 +79,7 @@ class BatchTest extends WP_UnitTestCase {
 	/**
 	 * Test without arguments
 	 */
-	public function test_register_batch_no_args() {
+	public function test_register_batch_doesnt_require_args() {
 		$batch_process = new Posts();
 		$batch_process->register( array(
 			'name'     => 'Hey there',
@@ -87,7 +87,7 @@ class BatchTest extends WP_UnitTestCase {
 			'callback' => 'my_callback_function',
 		) );
 
-			$this->assertNotNull( $batch_process->currently_registered['hey-there'] );
+		$this->assertNotNull( $batch_process->currently_registered['hey-there'] );
 	}
 
 	/**


### PR DESCRIPTION
Adds an empty array to args if none is defined in register_batch_process. The defaults are enough to process batches without this being required. Fixes #88