### PR TITLE
Rename top-level menu to Batches

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -78,7 +78,7 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
-		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -15,11 +15,11 @@ WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
 
 download() {
-    if [ `which curl` ]; then
-        curl -s "$1" > "$2";
-    elif [ `which wget` ]; then
-        wget -nv -O "$2" "$1"
-    fi
+		if [ `which curl` ]; then
+				curl -s "$1" > "$2";
+		elif [ `which wget` ]; then
+				wget -nv -O "$2" "$1"
+		fi
 }
 
 if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
@@ -78,6 +78,7 @@ install_test_suite() {
 	if [ ! -d $WP_TESTS_DIR ]; then
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 

--- a/locomotive.php
+++ b/locomotive.php
@@ -39,8 +39,8 @@ final class Loader {
 	 */
 	public function add_dashboard() {
 		add_menu_page(
-			'Locomotive',
-			'Locomotive',
+			__( 'Batch Processes' ),
+			__( 'Batches' ),
 			'manage_options',
 			'locomotive',
 			array( $this, 'dashboard_display' )

--- a/locomotive.php
+++ b/locomotive.php
@@ -38,7 +38,7 @@ final class Loader {
 	 * Admin Dashboard.
 	 */
 	public function add_dashboard() {
-		add_menu_page(
+		add_management_page(
 			__( 'Batch Processes' ),
 			__( 'Batches' ),
 			'manage_options',
@@ -88,7 +88,7 @@ final class Loader {
 	public function scripts( $hook ) {
 
 		// Exclude our scripts and CSS files from loading globally.
-		if ( 'toplevel_page_locomotive' !== $hook ) {
+		if ( 'tools_page_locomotive' !== $hook ) {
 			return;
 		}
 

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -99,7 +99,7 @@ class BatchFunctionTest extends WP_UnitTestCase {
 		$this->assertFalse( $this->are_batch_assets_enqueued() );
 
 		// Call our loader class on the locomotive settings page.
-		$this->load_admin_enqueue_hook( 'toplevel_page_locomotive' );
+		$this->load_admin_enqueue_hook( 'tools_page_locomotive' );
 
 		// Check that the items are enquened.
 		$this->assertTrue( $this->are_batch_assets_enqueued() );


### PR DESCRIPTION
Locomotive is fairly meaningless in the admin, this should
help users find the menu more easily.

Renamed the admin page title to 'Batch Processes' and made the strings
translatable.

Would love some other thoughts here :sparkles: