### PR TITLE
Fix offset issues

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -61,7 +61,7 @@
 	margin: auto;
 	position: absolute;
 	top: -650px;
-	left: 0; bottom: 0; right: 0;
+	left: 0; right: 0;
 
 	background: white;
 	box-shadow: 0 0 10px #ccc;

--- a/includes/abstracts/abstract-batch.php
+++ b/includes/abstracts/abstract-batch.php
@@ -144,14 +144,22 @@ abstract class Batch {
 	/**
 	 * Main plugin method for querying data.
 	 *
+	 * We need to run the query twice for each step. The first query is run in order to properly set
+	 * the total number of results retrieved from the *query*. This number is then compared to the original total
+	 * from the *request*, and a new offset is calculated based on these values. Once the offset is calculated, we
+	 * run the query again, this time actually pulling the results.
+	 *
 	 * @since 0.1
 	 *
 	 * @return mixed An array of data to be processed in bulk fashion.
 	 */
 	public function get_results() {
 		$this->args = wp_parse_args( $this->args, $this->default_args );
-		$results = $this->batch_get_results();
+		$this->batch_get_results();
 		$this->calculate_offset();
+
+		// Run query again, but this time with the new offset calculated.
+		$results = $this->batch_get_results();
 		return $results;
 	}
 

--- a/tests/test-batch.php
+++ b/tests/test-batch.php
@@ -196,6 +196,32 @@ class BatchTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that offset is applied properly to each step
+	 */
+	public function test_for_proper_offset() {
+		$this->factory->post->create_many( 10 );
+
+		$post_batch = new Posts();
+
+		$post_batch->register( array(
+			'name'     => 'Hey there',
+			'type'     => 'post',
+			'callback' => __NAMESPACE__ . '\\my_post_callback_function_test',
+			'args'     => array(
+				'posts_per_page' => 5,
+				'post_type'      => 'post',
+			),
+		) );
+
+		$first_run = $post_batch->run( 1 );
+		$second_run = $post_batch->run( 2 );
+
+		// Results from the first and second run should NOT match.
+		$this->assertNotEquals( $second_run['query_results'][0]->ID, $first_run['query_results'][0]->ID );
+
+	}
+
+	/**
 	 * Test that batch gets run.
 	 */
 	public function test_run_with_error() {

--- a/tests/types/test-batch-users.php
+++ b/tests/types/test-batch-users.php
@@ -134,9 +134,9 @@ class UserBatchTest extends WP_UnitTestCase {
 		$_POST['total_num_results'] = 9;
 		$user_batch->run( 2 );
 
-		// Check that all users have been deleted.
+		// Check that all users have been deleted. There should be one remaining, because of the main User ID.
 		$all_users = get_users();
-		$this->assertCount( 0, $all_users );
+		$this->assertCount( 1, $all_users );
 
 		// Ensure that we are still getting a finished message.
 		$batch_status = get_option( 'loco_batch_' . $user_batch->slug );


### PR DESCRIPTION
We have to run the query twice, once to get the total and calculate the offset, and once again to actually retrieve the results. A test has been added that compares results from step 1 and step 2 to ensure they are not the same. Also, removed ‘bottom’ attribute in CSS to fix overlay bug.