### PR TITLE
Feature allow custom batch processors

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -23,6 +23,8 @@ function register_batch_process( $args ) {
 		$args['type'] = '';
 	}
 
+	$batch_processor = get_default_batch_processor_for_type( $args['type'] );
+
 	/**
 	 * Filter the batch processor to be used with the batch process being registered.
 	 *
@@ -30,7 +32,7 @@ function register_batch_process( $args ) {
 	 * @param string $type            Type of data for this batch process.
 	 * @param array  $args            Arguments for the batch process.
 	 */
-	$batch_processor = apply_filters( 'loco_register_batch_process_processor', null, $args['type'], $args );
+	$batch_processor = apply_filters( 'loco_register_batch_process_processor', $batch_processor, $args['type'], $args );
 
 	if ( empty( $batch_processor ) ) {
 		return;
@@ -42,26 +44,6 @@ function register_batch_process( $args ) {
 
 	$batch_processor->register( $args );
 }
-
-/**
- * Filters the batch processor to use for default data types.
- *
- * @param Batch  $batch_processor The batch processor to use, defaults to null.
- * @param string $type            Type of data for this batch process.
- *
- * @return Batch The batch processor to use for a specific data type.
- */
-function register_default_batch_processors( $batch_processor, $type ) {
-    $default_processor = get_default_batch_processor_for_type( $type );
-
-    if ( ! $default_processor ) {
-        return $batch_processor;
-    }
-
-    return $default_processor;
-}
-
-add_filter( 'loco_register_batch_process_processor', __NAMESPACE__ . '\\register_default_batch_processors', 10, 2 );
 
 /**
  * Returns the default batch processor used for a specific type of data.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -52,34 +52,51 @@ function register_batch_process( $args ) {
  * @return Batch The batch processor to use for a specific data type.
  */
 function register_default_batch_processors( $batch_processor, $type ) {
+    $default_processor = get_default_batch_processor_for_type( $type );
+
+    if ( ! $default_processor ) {
+        return $batch_processor;
+    }
+
+    return $default_processor;
+}
+
+add_filter( 'loco_register_batch_process_processor', __NAMESPACE__ . '\\register_default_batch_processors', 10, 2 );
+
+/**
+ * Returns the default batch processor used for a specific type of data.
+ *
+ * @param string $type Type of data to get a batch processor for.
+ *
+ * @return Batch|null The batch processor to use for the specified type, null if not a default type.
+ */
+function get_default_batch_processor_for_type( $type ) {
 	switch ( $type ) {
 		case 'post':
-			$batch_processor = new Posts();
+			return new Posts();
 			break;
 
 		case 'user':
-			$batch_processor = new Users();
+			return new Users();
 			break;
 
 		case 'site':
 			if ( is_multisite() ) {
-				$batch_processor = new Sites();
+				return new Sites();
 			}
 			break;
 
 		case 'term':
-			$batch_processor = new Terms();
+			return new Terms();
 			break;
 
 		case 'comment':
-			$batch_processor = new Comments();
+			return new Comments();
 			break;
 	}
 
-	return $batch_processor;
+	return null;
 }
-
-add_filter( 'loco_register_batch_process_processor', __NAMESPACE__ . '\\register_default_batch_processors', 10, 2 );
 
 /**
  * Get the batch hooks that have been added and some info about them.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,7 +35,10 @@ function register_batch_process( $args ) {
 	$batch_processor = apply_filters( 'loco_register_batch_process_processor', $batch_processor, $args['type'], $args );
 
 	if ( empty( $batch_processor ) ) {
-		return;
+		throw new Exception( sprintf(
+			__( 'Batch processor not found for type "%1$s"', 'locomotive' ),
+			$args['type']
+		) );
 	}
 
 	if ( ! is_subclass_of( $batch_processor, 'Rkv\Locomotive\Abstracts\Batch' ) ) {


### PR DESCRIPTION
This is an update for #115 

It allows developers to use their own custom Batch Processor with the filter `'loco_register_batch_process_processor'`. This also adds a few unit tests for the additional code.